### PR TITLE
Use node-ip and node-external-ip flags for proper intra node traffic

### DIFF
--- a/modules/k3s_cluster/templates/user-data.tftpl
+++ b/modules/k3s_cluster/templates/user-data.tftpl
@@ -200,7 +200,9 @@ install_metallb(){
 }
 
 install_k3s(){
-	apt update && apt install curl -y
+	# Curl is needed to download the k3s binary
+	# Jq is needed to parse the Equinix Metal metadata (json format)
+	apt update && apt install curl jq -y
 
 	# Download the K3s installer script
 	curl -L --output k3s_installer.sh https://get.k3s.io && install -m755 k3s_installer.sh /usr/local/bin/
@@ -217,25 +219,27 @@ install_k3s(){
 
 	export INSTALL_K3S_SKIP_START=false
 	export K3S_TOKEN="${k3s_token}"
+	export NODE_IP=$(curl -s https://metadata.platformequinix.com/metadata | jq -r '.network.addresses[] | select(.public == false and .address_family == 4) |.address')
+	export NODE_EXTERNAL_IP=$(curl -s https://metadata.platformequinix.com/metadata | jq -r '.network.addresses[] | select(.public == true and .address_family == 4) |.address')
 %{ if node_type == "all-in-one" ~}
 %{ if global_ip_cidr != "" ~}
-	export INSTALL_K3S_EXEC="server --write-kubeconfig-mode=644 --disable=servicelb"
+	export INSTALL_K3S_EXEC="server --write-kubeconfig-mode=644 --disable=servicelb --node-ip $${NODE_IP} --node-external-ip $${NODE_EXTERNAL_IP}"
 %{ else ~}
 %{ if ip_pool != "" ~}
-	export INSTALL_K3S_EXEC="server --write-kubeconfig-mode=644 --disable=servicelb"
+	export INSTALL_K3S_EXEC="server --write-kubeconfig-mode=644 --disable=servicelb --node-ip $${NODE_IP} --node-external-ip $${NODE_EXTERNAL_IP}"
 %{ else ~}
-	export INSTALL_K3S_EXEC="server --write-kubeconfig-mode=644"
+	export INSTALL_K3S_EXEC="server --write-kubeconfig-mode=644 --node-ip $${NODE_IP} --node-external-ip $${NODE_EXTERNAL_IP}"
 %{ endif ~}
 %{ endif ~}
 %{ endif ~}
 %{ if node_type == "control-plane-master" ~}
-	export INSTALL_K3S_EXEC="server --cluster-init --write-kubeconfig-mode=644 --tls-san=${API_IP} --tls-san=${API_IP}.sslip.io --disable=servicelb"
+	export INSTALL_K3S_EXEC="server --cluster-init --write-kubeconfig-mode=644 --tls-san=${API_IP} --tls-san=${API_IP}.sslip.io --disable=servicelb --node-ip $${NODE_IP} --node-external-ip $${NODE_EXTERNAL_IP}"
 %{ endif ~}
 %{ if node_type == "control-plane" ~}
-	export INSTALL_K3S_EXEC="server --server https://${API_IP}:6443 --write-kubeconfig-mode=644"
+	export INSTALL_K3S_EXEC="server --server https://${API_IP}:6443 --write-kubeconfig-mode=644 --node-ip $${NODE_IP} --node-external-ip $${NODE_EXTERNAL_IP}"
 %{ endif ~}
 %{ if node_type == "node" ~}
-	export K3S_URL="https://${API_IP}:6443"
+	export INSTALL_K3S_EXEC="agent --server https://${API_IP}:6443 --node-ip $${NODE_IP} --node-external-ip $${NODE_EXTERNAL_IP}"
 %{ endif ~}
 %{ if k3s_version != "" ~}
 	export INSTALL_K3S_VERSION=${k3s_version}


### PR DESCRIPTION
Closes #80 

```
❯ (
MODULENAME="demo_cluster"
IFS=$'\n'
for cluster in $(terraform output -json | jq -r ".${MODULENAME}.value.k3s_api | keys[]"); do
  IP=$(terraform output -json | jq -r ".${MODULENAME}.value.k3s_api[\"${cluster}\"]")
  ssh -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${IP} kubectl get nodes -o wide
done
)
NAME                        STATUS   ROLES                       AGE     VERSION        INTERNAL-IP    EXTERNAL-IP     OS-IMAGE                         KERNEL-VERSION    CONTAINER-RUNTIME
sv-production-k3s-cp-0      Ready    control-plane,etcd,master   2m39s   v1.30.4+k3s1   10.67.34.141   139.178.70.53   Debian GNU/Linux 11 (bullseye)   5.10.0-32-amd64   containerd://1.7.20-k3s1
sv-production-k3s-cp-1      Ready    control-plane,etcd,master   14s     v1.30.4+k3s1   10.67.34.137   147.75.90.243   Debian GNU/Linux 11 (bullseye)   5.10.0-32-amd64   containerd://1.7.20-k3s1
sv-production-k3s-cp-2      Ready    control-plane,etcd,master   30s     v1.30.4+k3s1   10.67.34.135   147.75.90.215   Debian GNU/Linux 11 (bullseye)   5.10.0-32-amd64   containerd://1.7.20-k3s1
sv-production-k3s-node-00   Ready    <none>                      45s     v1.30.4+k3s1   10.67.34.133   147.75.90.147   Debian GNU/Linux 11 (bullseye)   5.10.0-32-amd64   containerd://1.7.20-k3s1
sv-production-k3s-node-01   Ready    <none>                      50s     v1.30.4+k3s1   10.67.34.129   147.28.180.81   Debian GNU/Linux 11 (bullseye)   5.10.0-32-amd64   containerd://1.7.20-k3s1
sv-production-k3s-node-02   Ready    <none>                      55s     v1.30.4+k3s1   10.67.34.131   147.75.90.143   Debian GNU/Linux 11 (bullseye)   5.10.0-32-amd64   containerd://1.7.20-k3s1
```